### PR TITLE
feat: Put additional DESeq2 parameters under user control

### DIFF
--- a/DE_pipeline.snake
+++ b/DE_pipeline.snake
@@ -470,8 +470,10 @@ rule DESeq2:
 		annot_pkg  = config["organism"]["R"]["annotations"]
 	run:
 		config_file = pph.file_path(step="pipeline_report", extension="yaml", contrast="all")
-		count_threshold       = config["filters"]["low_counts"]
-		normalized_expression = config["normalization"]["normalized_expression"]
+		count_threshold       =           config["filters"]["low_counts"]
+		deseq2_parameters     =           config["normalization"]["DESeq2_parameters"]
+		deseq2_parameter_useT = "TRUE" if config["normalization"]["DESeq2_parameters"]["useT"] else "FALSE"
+		normalized_expression =           config["normalization"]["normalized_expression"]
 		script = textwrap.dedent(r"""
 		#----- import packages
 		library(DESeq2)
@@ -500,8 +502,17 @@ rule DESeq2:
 		dds  <- dds[keep,]; print(dds)
 		
 		#----- DESeq2
-		dds <- DESeq(dds, betaPrior=FALSE, test="Wald")
-
+		deseq_args <- list(
+            object=dds,
+			test="Wald",
+			betaPrior=FALSE,
+			fitType="{deseq2_parameters[fitType]}",
+			sfType="{deseq2_parameters[sfType]}",
+			useT={deseq2_parameter_useT},
+			minReplicatesForReplace={deseq2_parameters[minReplicatesForReplace]},
+			minmu={deseq2_parameters[minmu]}
+		)
+		dds <- do.call(DESeq, args=deseq_args)
 		# ----- Normalised expression values
 		rld_blind <- switch("{normalized_expression}",
 			"rld"=rlog(dds, blind=TRUE),

--- a/defaults/DE_config_defaults.yaml
+++ b/defaults/DE_config_defaults.yaml
@@ -49,7 +49,11 @@ filters:
 #---------------------------------------- normalization parameters
 normalization:
   DESeq2_parameters:
-    min_mu: 0
+    fitType: parametric
+    sfType: ratio
+    minReplicatesForReplace: 7
+    useT: false
+    minmu: 0.5
   normalized_expression: vst
 
 #---------------------------------------- description of contrasts

--- a/defaults/DE_config_ranges.yaml
+++ b/defaults/DE_config_ranges.yaml
@@ -50,18 +50,22 @@ filters:
 #---------------------------------------- normalization parameters
 normalization:
   DESeq2_parameters:
-    min_mu: {"__num__": [0, null]}
+    fitType: parametric|local|mean|glmGamPoi
+    sfType: ratio|poscounts|iterate
+    minReplicatesForReplace: {"__num__": [0, null]}
+    useT: {"__opt__": [true, false]}
+    minmu: {"__num__": [0, null]}
   normalized_expression: vst|rld
 
 #---------------------------------------- description of contrasts
 contrasts:
   defaults:
     max_p_adj: {"__num__": [0, 1]}
-    ranking_by: log2FoldChange|pvalue|padj
+    ranking_by: log2FoldChange|stat|pvalue|padj
     ranking_order: .*
     results_parameters:
       lfcThreshold: {"__num__": [0, null]}
-      altHypothesis: greaterAbs|lessAbs|greater|less
+      altHypothesis: greaterAbs|lessAbs|greater|less|greaterAbs2014
       independentFiltering:
         __opt__: [true, false]
     lfcShrink_parameters:


### PR DESCRIPTION
Puts a few `DESeq2` parameters under user control, fixes #34 

More parameters may still be put under user control, in particular the test type (which is set to `Wald`). But doing that requires much more work, and I am not sure it is warranted.